### PR TITLE
Fix no args

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ lazy val root = project
     name := "GUInep-root",
     publish / skip := true
   )
-  .aggregate((guinep.projectRefs ++ web.projectRefs): _*)
+  .aggregate((guinep.projectRefs ++ web.projectRefs ++ testcases.projectRefs): _*)
 
 lazy val guinep = projectMatrix
   .in(file("guinep"))

--- a/guinep/src/main/scala/macros.scala
+++ b/guinep/src/main/scala/macros.scala
@@ -41,6 +41,8 @@ private[guinep] object macros {
           getMostInnerApply(body).getOrElse(wrongParamsListError(f))
         case Lambda(_, body) =>
           getMostInnerApply(body).getOrElse(wrongParamsListError(f))
+        case Ident(name) =>
+          name
         case _ =>
           wrongParamsListError(f)
       }
@@ -48,8 +50,10 @@ private[guinep] object macros {
     }
 
     private def functionParams(f: Expr[Any]): Seq[ValDef] = f.asTerm match {
-      case Lambda(params, body) =>
+      case Lambda(params, _) =>
         params.map (param => param)
+      case Ident(_) =>
+        Nil
       case _ =>
         wrongParamsListError(f)
     }
@@ -144,27 +148,38 @@ private[guinep] object macros {
       }
     }
 
-    private def functionRunImpl(f: Expr[Any]): Expr[List[Any] => String] = {
-      val fTerm = f.asTerm
-      f.asTerm match {
-        case l@Lambda(params, body) =>
-          /* (params: List[Any]) => l.apply(params(0).asInstanceOf[String], params(1).asInstanceOf[Int], ...) */
-          Lambda(
-            Symbol.spliceOwner,
-            MethodType(List("inputs"))(_ => List(TypeRepr.of[List[Any]]),  _ => TypeRepr.of[String]),
-            { case (sym, List(params: Term)) =>
-              l.select("apply").appliedToArgs(
-                functionParams(f).zipWithIndex.map { case (valdef, i) =>
-                  val paramTpe = valdef.tpt.tpe
-                  val param = params.select("apply").appliedTo(Literal(IntConstant(i)))
-                  constructArg(paramTpe, param)
-                }.toList
-              ).select("toString").appliedToNone
-            }
-          ).asExprOf[List[Any] => String]
-        case _ =>
-          wrongParamsListError(f)
-      }
+    @scala.annotation.nowarn("msg=match may not be exhaustive")
+    private def functionRunImpl(f: Expr[Any]): Expr[List[Any] => String] = f.asTerm match {
+      case l@Lambda(params, _) =>
+        /* (params: List[Any]) => l.apply(constructArg(params(0)), constructArg(params(1)), ...) */
+        Lambda(
+          Symbol.spliceOwner,
+          MethodType(List("inputs"))(_ => List(TypeRepr.of[List[Any]]),  _ => TypeRepr.of[String]),
+          { case (sym, List(params: Term)) =>
+            val args = functionParams(f).zipWithIndex.map { case (valdef, i) =>
+              val paramTpe = valdef.tpt.tpe
+              val param = params.select("apply").appliedTo(Literal(IntConstant(i)))
+              constructArg(paramTpe, param)
+            }.toList
+            val aply = l.select("apply")
+            val res =
+              if args.isEmpty then
+                aply.appliedToNone
+              else
+                aply.appliedToArgs(args)
+            res.select("toString").appliedToNone
+          }
+        ).asExprOf[List[Any] => String]
+      case i@Ident(_) =>
+        Lambda(
+          Symbol.spliceOwner,
+          MethodType(List("inputs"))(_ => List(TypeRepr.of[List[Any]]),  _ => TypeRepr.of[String]),
+          { case (sym, List(params: Term)) =>
+            i.select("toString").appliedToNone
+          }
+        ).asExprOf[List[Any] => String]
+      case _ =>
+        wrongParamsListError(f)
     }
 
     def funInfosImpl(fs: Expr[Any]): Expr[Seq[Fun]] = {

--- a/guinep/src/main/scala/macros.scala
+++ b/guinep/src/main/scala/macros.scala
@@ -43,6 +43,8 @@ private[guinep] object macros {
           getMostInnerApply(body).getOrElse(wrongParamsListError(f))
         case Ident(name) =>
           name
+        case Apply(Ident(name), Nil) =>
+          name
         case _ =>
           wrongParamsListError(f)
       }
@@ -53,6 +55,8 @@ private[guinep] object macros {
       case Lambda(params, _) =>
         params.map (param => param)
       case Ident(_) =>
+        Nil
+      case Apply(Ident(_), Nil) =>
         Nil
       case _ =>
         wrongParamsListError(f)
@@ -176,6 +180,14 @@ private[guinep] object macros {
           MethodType(List("inputs"))(_ => List(TypeRepr.of[List[Any]]),  _ => TypeRepr.of[String]),
           { case (sym, List(params: Term)) =>
             i.select("toString").appliedToNone
+          }
+        ).asExprOf[List[Any] => String]
+      case a@Apply(Ident(_), Nil) =>
+        Lambda(
+          Symbol.spliceOwner,
+          MethodType(List("inputs"))(_ => List(TypeRepr.of[List[Any]]),  _ => TypeRepr.of[String]),
+          { case (sym, List(params: Term)) =>
+            a.select("toString").appliedToNone
           }
         ).asExprOf[List[Any] => String]
       case _ =>

--- a/testcases/src/main/scala/main.scala
+++ b/testcases/src/main/scala/main.scala
@@ -54,6 +54,9 @@ def nameWithPossiblePrefix1(name: String, maybePrefix: MaybeString1): String =
 def roll20: Int =
   scala.util.Random.nextInt(20) + 1
 
+def roll6(): Int =
+  scala.util.Random.nextInt(6) + 1
+
 @main
 def run: Unit =
   guinep.web(
@@ -67,5 +70,6 @@ def run: Unit =
     greetInLanguage,
     nameWithPossiblePrefix,
     nameWithPossiblePrefix1,
-    roll20
+    roll20,
+    roll6()
   )

--- a/testcases/src/main/scala/main.scala
+++ b/testcases/src/main/scala/main.scala
@@ -51,6 +51,9 @@ def nameWithPossiblePrefix1(name: String, maybePrefix: MaybeString1): String =
     case MaybeString1.JustString(value) => s"$value $name"
     case MaybeString1.NoString => name
 
+def roll20: Int =
+  scala.util.Random.nextInt(20) + 1
+
 @main
 def run: Unit =
   guinep.web(
@@ -63,5 +66,6 @@ def run: Unit =
     // greetMaybeName,
     greetInLanguage,
     nameWithPossiblePrefix,
-    nameWithPossiblePrefix1
+    nameWithPossiblePrefix1,
+    roll20
   )


### PR DESCRIPTION
Add support for no arg functions and functions with empty param lists.

e.g.
```scala
def roll20: Int =
  scala.util.Random.nextInt(20) + 1

def roll6(): Int =
  scala.util.Random.nextInt(6) + 1

@main
def run: Unit =
  guinep.web(
    roll20,
    roll6() // roll6 has to have parentheses here since otherwise it gives an error before inlining (might be unintentional in dotty)
  )
```