### PR TITLE
Run function lifting and named form refs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,8 @@ val commonSettings = Seq(
     "-explain",
     "-deprecation",
     "-unchecked",
-    "-feature"
+    "-feature",
+    // "-Xprint:inlining"
   ),
   libraryDependencies ++= Seq(
     "org.scalameta" %%% "munit" % "1.0.0-M6" % Test
@@ -40,7 +41,10 @@ lazy val guinep = projectMatrix
   .in(file("guinep"))
   .settings(commonSettings)
   .settings(
-    name := "GUInep"
+    name := "GUInep",
+    libraryDependencies ++= Seq(
+      "com.softwaremill.quicklens" %%% "quicklens" % "1.9.7"
+    )
   )
   .jvmPlatform(scalaVersions = List(scala3))
 

--- a/build.sbt
+++ b/build.sbt
@@ -20,8 +20,7 @@ val commonSettings = Seq(
     "-explain",
     "-deprecation",
     "-unchecked",
-    "-feature",
-    // "-Xprint:inlining"
+    "-feature"
   ),
   libraryDependencies ++= Seq(
     "org.scalameta" %%% "munit" % "1.0.0-M6" % Test

--- a/guinep/src/main/scala/macros.scala
+++ b/guinep/src/main/scala/macros.scala
@@ -2,6 +2,8 @@ package guinep
 
 import guinep.model.*
 import scala.quoted.*
+import scala.collection.mutable
+import com.softwaremill.quicklens.*
 
 private[guinep] object macros {
   inline def funInfos(inline fs: Any): Seq[Fun] =
@@ -33,7 +35,13 @@ private[guinep] object macros {
     extension (t: Term)
       private def select(s: Term): Term = Select(t, s.symbol)
       private def select(s: String): Term =
-        t.select(t.tpe.typeSymbol.methodMember(s).head)
+        t.select(
+          t.tpe
+            .typeSymbol
+            .methodMember(s)
+            .headOption.
+            getOrElse(report.errorAndAbort(s"PANIC: No member $s in term ${t.show} with type ${t.tpe.show}"))
+        )
 
     extension (s: Symbol)
       private def prettyName: String =
@@ -93,7 +101,27 @@ private[guinep] object macros {
       val isEnumCaseNonClassDef = typeSymbol.flags.is(Flags.Enum) && typeSymbol.flags.is(Flags.Case) && !typeSymbol.isClassDef
       isModule || isEnumCaseNonClassDef
 
-    private def functionFormElementFromTree(paramName: String, paramType: TypeRepr): FormElement = paramType match {
+    private case class FormConstrContext(constructedTpes: mutable.Map[String, Option[FormElement]], referencedTpes: mutable.Set[String])
+    private def formConstrCtx(using FormConstrContext) = summon[FormConstrContext]
+
+    extension (tpe: TypeRepr)
+      private def namedRef: String = tpe match
+        case ntpe: NamedType => ntpe.typeSymbol.fullName
+        case AppliedType(tpe, args) => s"${tpe.namedRef}[${args.map(_.namedRef).mkString(", ")}]"
+        case AnnotatedType(tpe, _) => tpe.namedRef
+        case _ => tpe.show
+    private def functionFormElementFromTreeWithCaching(paramName: String, paramTpe: TypeRepr)(using FormConstrContext): FormElement =
+      formConstrCtx.constructedTpes.get(paramTpe.namedRef) match
+        case Some(_) =>
+          formConstrCtx.referencedTpes.add(paramTpe.namedRef)
+          FormElement.NamedRef(paramName, paramTpe.namedRef)
+        case _ =>
+          formConstrCtx.constructedTpes.update(paramTpe.namedRef, None)
+          val formElement = functionFormElementFromTree(paramName, paramTpe)
+          formConstrCtx.constructedTpes.update(paramTpe.namedRef, Some(formElement.modify(_.name).setTo("value")))
+          formElement
+
+    private def functionFormElementFromTree(paramName: String, paramType: TypeRepr)(using FormConstrContext): FormElement = paramType match {
       case ntpe: NamedType if ntpe.name == "String" => FormElement.TextInput(paramName)
       case ntpe: NamedType if ntpe.name == "Int" => FormElement.NumberInput(paramName)
       case ntpe: NamedType if ntpe.name == "Boolean" => FormElement.CheckboxInput(paramName)
@@ -104,7 +132,7 @@ private[guinep] object macros {
         FormElement.FieldSet(
           paramName,
           fields.map { valdef =>
-            functionFormElementFromTree(
+            functionFormElementFromTreeWithCaching(
               valdef.name,
               valdef.tpt.tpe.substituteTypes(typeDefParams, ntpe.typeArgs).stripAnnots
             )
@@ -113,17 +141,29 @@ private[guinep] object macros {
       case ntpe if isSumTpe(ntpe) =>
         val classSymbol = ntpe.typeSymbol
         val childrenAppliedTpes = classSymbol.children.map(child => appliedChild(child, classSymbol, ntpe.typeArgs)).map(_.stripAnnots)
-        val childrenFormElements = childrenAppliedTpes.map(t => functionFormElementFromTree("value", t))
+        val childrenFormElements = childrenAppliedTpes.map(t => functionFormElementFromTreeWithCaching("value", t))
         val options = classSymbol.children.map(_.prettyName).zip(childrenFormElements)
         FormElement.Dropdown(paramName, options)
       case _ =>
         unsupportedFunctionParamType(paramType)
     }
 
-    private def functionFormElementsImpl(f: Expr[Any]): Expr[Seq[FormElement]] =
-      Expr.ofSeq(
-        functionParams(f).map { case ValDef(name, tpt, _) => functionFormElementFromTree(name, tpt.tpe) } .map(Expr(_))
-      )
+    private def formImpl(f: Expr[Any]): Expr[Form] =
+      given FormConstrContext = FormConstrContext(mutable.Map.empty, mutable.Set.empty)
+      val inputs = functionParams(f)
+        .map {
+          case ValDef(name, tpt, _) =>
+            functionFormElementFromTreeWithCaching(name, tpt.tpe)
+        }
+      val usedFormDecls =
+        formConstrCtx.constructedTpes
+          .toList.filter( (ref, formElement) => formConstrCtx.referencedTpes.contains(ref)  )
+          .collect {
+            case (ref, Some(formElement)) => ref -> formElement
+          }
+          .toMap
+      val form = Form(inputs, usedFormDecls)
+      Expr(form)
 
     private def appliedChild(childSym: Symbol, parentSym: Symbol, parentArgs: List[TypeRepr]): TypeRepr = childSym.tree match {
       case classDef @ ClassDef(_, _, parents, _, _) =>
@@ -149,7 +189,29 @@ private[guinep] object macros {
         childSym.typeRef
     }
 
-    private def constructArg(paramTpe: TypeRepr, param: Term): Term = {
+    private case class ConstrEntry(definition: Option[Statement], ref: Term)
+    private case class ConstrContext(constrMap: mutable.Map[String, ConstrEntry])
+    private def constrCtx(using ConstrContext) = summon[ConstrContext]
+
+    private def constructArgWithCaching(paramTpe: TypeRepr, param: Term)(using ConstrContext): Term = constrCtx.constrMap.get(paramTpe.namedRef) match
+      case Some(ConstrEntry(_, ref)) =>
+        ref.appliedTo(param)
+      case None =>
+        val ConstrEntry(_, ref) = constructFunction(paramTpe)
+        ref.appliedTo(param)
+
+    private def constructFunction(paramTpe: TypeRepr)(using ConstrContext): ConstrEntry =
+      val defdefSymbol = Symbol.newMethod(Symbol.spliceOwner, s"constrFunFor${paramTpe.typeSymbol.name}", MethodType(List("inputs"))(_ => List(TypeRepr.of[Any]),  _ => paramTpe))
+      constrCtx.constrMap.update(paramTpe.namedRef, ConstrEntry(None, Ref(defdefSymbol)))
+      val defdef = DefDef(defdefSymbol, {
+        case List(List(param: Term)) =>
+          Some(constructArg(paramTpe, param))
+      })
+      val constrEntry = ConstrEntry(Some(defdef), Ref(defdefSymbol))
+      val newMap = constrCtx.constrMap.update(paramTpe.namedRef, constrEntry)
+      constrEntry
+
+    private def constructArg(paramTpe: TypeRepr, param: Term)(using ConstrContext): Term = {
       paramTpe match {
         case ntpe: NamedType if ntpe.name == "String" => param.select("asInstanceOf").appliedToType(ntpe)
         case ntpe: NamedType if ntpe.name == "Int" => param.select("asInstanceOf").appliedToType(ntpe)
@@ -166,7 +228,7 @@ private[guinep] object macros {
           val args = fields.collect { case field: ValDef =>
             val fieldName = field.name
             val fieldValue = paramValue.select("apply").appliedTo(Literal(StringConstant(fieldName)))
-            constructArg(
+            constructArgWithCaching(
               field.tpt.tpe.substituteTypes(typeDefParams, ntpe.typeArgs),
               fieldValue
             )
@@ -186,7 +248,7 @@ private[guinep] object macros {
             val childName = Literal(StringConstant(child.prettyName))
             If(
               paramName.select("equals").appliedTo(childName),
-              constructArg(childAppliedTpe, paramValue),
+              constructArgWithCaching(childAppliedTpe, paramValue),
               acc
             )
           }
@@ -199,14 +261,15 @@ private[guinep] object macros {
     private def functionRunImpl(f: Expr[Any]): Expr[List[Any] => String] = f.asTerm match {
       case l@Lambda(params, _) =>
         /* (params: List[Any]) => l.apply(constructArg(params(0)), constructArg(params(1)), ...) */
-        Lambda(
+        given ConstrContext = ConstrContext(mutable.Map.empty)
+        val resLambda = Lambda(
           Symbol.spliceOwner,
           MethodType(List("inputs"))(_ => List(TypeRepr.of[List[Any]]),  _ => TypeRepr.of[String]),
           { case (sym, List(params: Term)) =>
             val args = functionParams(f).zipWithIndex.map { case (valdef, i) =>
               val paramTpe = valdef.tpt.tpe
               val param = params.select("apply").appliedTo(Literal(IntConstant(i)))
-              constructArg(paramTpe, param)
+              constructArgWithCaching(paramTpe, param)
             }.toList
             val aply = l.select("apply")
             val res =
@@ -216,6 +279,10 @@ private[guinep] object macros {
                 aply.appliedToArgs(args)
             res.select("toString").appliedToNone
           }
+        )
+        Block(
+          constrCtx.constrMap.toList.flatMap(_._2.definition),
+          resLambda
         ).asExprOf[List[Any] => String]
       case i@Ident(_) =>
         Lambda(
@@ -249,9 +316,9 @@ private[guinep] object macros {
 
     def funInfoImpl(f: Expr[Any]): Expr[Fun] = {
       val name = functionNameImpl(f)
-      val params = functionFormElementsImpl(f)
+      val form = formImpl(f)
       val run = functionRunImpl(f)
-      '{ Fun($name, $params, $run) }
+      '{ Fun($name, $form, $run) }
     }
   }
 }

--- a/guinep/src/main/scala/model.scala
+++ b/guinep/src/main/scala/model.scala
@@ -3,10 +3,26 @@ package guinep
 import scala.quoted.*
 
 private[guinep] object model {
-  case class Fun(name: String, inputs: Seq[FormElement], run: List[Any] => String)
+  case class Fun(name: String, form: Form, run: List[Any] => String)
+
+  case class Form(inputs: Seq[FormElement], namedFormElements: Map[String, FormElement]) {
+    def formElementsJSONRepr =
+      val elems = this.inputs.map(_.toJSONRepr).mkString(",")
+      s"[$elems]"
+    def namedFormElementsJSONRepr: String =
+      val entries = this.namedFormElements.toList.map { (name, formElement) =>
+        s""""$name": ${formElement.toJSONRepr}"""
+      }
+      .mkString(",")
+      s"{$entries}"
+  }
+  object Form:
+    given ToExpr[Form] with
+      def apply(form: Form)(using Quotes): Expr[Form] = form match
+        case Form(inputs, namedFormElements) =>
+          '{ Form(${Expr(inputs)}, ${Expr(namedFormElements)}) }
 
   enum FormElement(val name: String):
-    case FieldSet(override val name: String, elements: List[FormElement]) extends FormElement(name)
     case TextInput(override val name: String) extends FormElement(name)
     case NumberInput(override val name: String) extends FormElement(name)
     case CheckboxInput(override val name: String) extends FormElement(name)
@@ -15,6 +31,20 @@ private[guinep] object model {
     case DateInput(override val name: String) extends FormElement(name)
     case EmailInput(override val name: String) extends FormElement(name)
     case PasswordInput(override val name: String) extends FormElement(name)
+    case FieldSet(override val name: String, elements: List[FormElement]) extends FormElement(name)
+    case NamedRef(override val name: String, ref: String) extends FormElement(name)
+
+    def constrOrd: Int = this match
+      case TextInput(_) => 0
+      case NumberInput(_) => 1
+      case CheckboxInput(_) => 2
+      case Dropdown(_, _) => 3
+      case TextArea(_, _, _) => 4
+      case DateInput(_) => 5
+      case EmailInput(_) => 6
+      case PasswordInput(_) => 7
+      case FieldSet(_, _) => 8
+      case NamedRef(_, _) => 9
 
     def toJSONRepr: String = this match
       case FormElement.FieldSet(name, elements) =>
@@ -26,7 +56,8 @@ private[guinep] object model {
       case FormElement.CheckboxInput(name) =>
         s"""{ "name": '$name', "type": 'checkbox' }"""
       case FormElement.Dropdown(name, options) =>
-        s"""{ "name": '$name', "type": 'dropdown', "options": [${options.map { case (k, v) => s"""{"name": "$k", "value": ${v.toJSONRepr}}""" }.mkString(",")}] }"""
+        // TODO(kπ) this sortBy isn't 100% sure to be working (the only requirement is for the first constructor to not be recursive; this is a graph problem, sorta)
+        s"""{ "name": '$name', "type": 'dropdown', "options": [${options.sortBy(_._2).map { case (k, v) => s"""{"name": "$k", "value": ${v.toJSONRepr}}""" }.mkString(",")}] }"""
       case FormElement.TextArea(name, rows, cols) =>
         s"""{ "name": '$name', "type": 'textarea', "rows": ${rows.getOrElse("")}, "cols": ${cols.getOrElse("")} }"""
       case FormElement.DateInput(name) =>
@@ -35,6 +66,8 @@ private[guinep] object model {
         s"""{ "name": '$name', "type": 'email' }"""
       case FormElement.PasswordInput(name) =>
         s"""{ "name": '$name', "type": 'password' }"""
+      case FormElement.NamedRef(name, ref) =>
+        s"""{ "name": '$name', "ref": '$ref', "type": 'namedref' }"""
 
   object FormElement:
     given ToExpr[FormElement] with
@@ -57,4 +90,18 @@ private[guinep] object model {
           '{ FormElement.EmailInput(${Expr(name)}) }
         case FormElement.PasswordInput(name) =>
           '{ FormElement.PasswordInput(${Expr(name)}) }
+        case FormElement.NamedRef(name, ref) =>
+          '{ FormElement.NamedRef(${Expr(name)}, ${Expr(ref)}) }
+
+    given Ordering[FormElement] = new Ordering[FormElement] {
+      def compare(x: FormElement, y: FormElement): Int =
+        if x.constrOrd < y.constrOrd then -1
+        else if x.constrOrd > y.constrOrd then 1
+        else (x, y) match
+          case (FormElement.FieldSet(_, elems1), FormElement.FieldSet(_, elems2)) =>
+            elems1.size - elems2.size
+          case (FormElement.Dropdown(_, opts1), FormElement.Dropdown(_, opts2)) =>
+            opts1.size - opts2.size
+          case _ => 0
+  }
 }

--- a/testcases/src/main/scala/main.scala
+++ b/testcases/src/main/scala/main.scala
@@ -67,7 +67,6 @@ def printsWeirdGADT(g: WeirdGADT[String]): String = g match
   case SomeValue(value) => s"SomeValue($value)"
   case SomeOtherValue(value, value2) => s"SomeOtherValue($value, $value2)"
 
-// This loops forever
 def concatAll(elems: List[String]): String =
   elems.mkString
 
@@ -86,6 +85,6 @@ def run: Unit =
     nameWithPossiblePrefix1,
     roll20,
     roll6(),
+    concatAll,
     // printsWeirdGADT
-    // concatAll
   )

--- a/testcases/src/main/scala/main.scala
+++ b/testcases/src/main/scala/main.scala
@@ -86,6 +86,9 @@ extension (elem: Int)
   case IntTree.Node(left, value, right) =>
     value == elem || elem.isInTreeExt(left) || elem.isInTreeExt(right)
 
+def addManyParamLists(a: Int)(b: Int): Int =
+  a + b
+
 @main
 def run: Unit =
   guinep.web(
@@ -104,5 +107,6 @@ def run: Unit =
     concatAll,
     isInTree,
     // isInTreeExt
+    // addManyParamLists
     // printsWeirdGADT
   )

--- a/testcases/src/main/scala/main.scala
+++ b/testcases/src/main/scala/main.scala
@@ -70,6 +70,22 @@ def printsWeirdGADT(g: WeirdGADT[String]): String = g match
 def concatAll(elems: List[String]): String =
   elems.mkString
 
+enum IntTree:
+  case Leaf
+  case Node(left: IntTree, value: Int, right: IntTree)
+
+def isInTree(elem: Int, tree: IntTree): Boolean = tree match
+  case IntTree.Leaf => false
+  case IntTree.Node(left, value, right) =>
+    value == elem || isInTree(elem, left) || isInTree(elem, right)
+
+// Can't be handled right now
+extension (elem: Int)
+  def isInTreeExt(tree: IntTree): Boolean = tree match
+  case IntTree.Leaf => false
+  case IntTree.Node(left, value, right) =>
+    value == elem || elem.isInTreeExt(left) || elem.isInTreeExt(right)
+
 @main
 def run: Unit =
   guinep.web(
@@ -86,5 +102,7 @@ def run: Unit =
     roll20,
     roll6(),
     concatAll,
+    isInTree,
+    // isInTreeExt
     // printsWeirdGADT
   )

--- a/web/src/main/scala/htmlgen.scala
+++ b/web/src/main/scala/htmlgen.scala
@@ -20,7 +20,7 @@ private[guinep] trait HtmlGen {
           .sidebar a { display: block; padding: 10px; margin-bottom: 10px; background-color: #007bff; color: white; text-decoration: none; text-align: center; border-radius: 5px; }
           .sidebar a:hover { background-color: #0056b3; }
           .main-content { margin-left: 232px; padding: 40px; display: flex; justify-content: center; padding-top: 20px; }
-          .form-container { width: 300px; }
+          .form-container { width: 600px; }
           label { display: inline-block; margin-right: 10px; vertical-align: middle; }
           input:not([type=submit]) { display: inline-block; padding: 8px; margin-bottom: 10px; box-sizing: border-box; }
           input[type=submit] { background-color: #4CAF50; color: white; padding: 10px 20px; border: none; border-radius: 4px; cursor: pointer; }

--- a/web/src/main/scala/webgen.scala
+++ b/web/src/main/scala/webgen.scala
@@ -33,8 +33,9 @@ private[guinep] object webgen {
             str <- req.body.asString
             obj <- ZIO.fromEither(str.fromJson[Obj])
             fun = funs(name)
-            inputsValuesMap <- ZIO.fromEither(fun.inputs.toList.parseJSONValue(obj))
-            inputsValues = fun.inputs.toList.sortByArgs(inputsValuesMap)
+            given Map[String, FormElement] = fun.form.namedFormElements
+            inputsValuesMap <- ZIO.fromEither(fun.form.inputs.toList.parseJSONValue(obj))
+            inputsValues = fun.form.inputs.toList.sortByArgs(inputsValuesMap)
             result = fun.run(inputsValues)
           } yield Response.text(result)).onError(e => ZIO.debug(e.toString))
         }

--- a/web/src/main/scala/webgen.scala
+++ b/web/src/main/scala/webgen.scala
@@ -17,7 +17,10 @@ private[guinep] object webgen {
     val ws = WebServer(funs)
     val runtime = Runtime.default
     Unsafe.unsafe { implicit unsafe =>
-      runtime.unsafe.run(ws.run)
+      runtime.unsafe.run(
+        ws.run
+          .race(Console.readLine("Press ENTER to stop...").*>(Console.printLine("Stopping...")))
+      )
     }
   }
 


### PR DESCRIPTION
This PR implements the support for recursive data structures

e.g.

```scala
enum IntTree:
  case Leaf
  case Node(left: IntTree, value: Int, right: IntTree)

def isInTree(elem: Int, tree: IntTree): Boolean = tree match
  case IntTree.Leaf => false
  case IntTree.Node(left, value, right) =>
    value == elem || isInTree(elem, left) || isInTree(elem, right)
```

closes #29 